### PR TITLE
Build pricing intelligence SaaS starter kit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
-# MONEY
-MONEY
+# Profit Platform
+
+Profit Platform is a pricing-intelligence SaaS starter kit. It helps digital product
+founders and agencies monetise by providing:
+
+- **Product catalog management** with sales observations stored in SQLite.
+- **Automatic pricing insights** that estimate conversion rates, revenue per visitor,
+  and elasticity, then recommend a winning price point.
+- **Experiment tracking** so you can document hypotheses and AB-test offers.
+- **Lightweight JSON API** powered by the Python standard library so you can deploy
+  anywhere without extra dependencies.
+
+Use it as the foundation for a premium pricing optimizer that you can charge for via
+subscriptions, consulting retainers, or enterprise licences.
+
+## Quick start
+
+Create a virtual environment and install the project in editable mode:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Initialise the database and seed it with demo data:
+
+```bash
+python -m profit_platform.cli --database demo.db init-db
+python -m profit_platform.cli --database demo.db seed-demo
+```
+
+Launch the HTTP API server (built on `wsgiref.simple_server`):
+
+```bash
+python -m profit_platform.cli --database demo.db serve --port 8080
+```
+
+Visit `http://localhost:8080/health` for a quick status check. Pair the
+backend with a React or no-code dashboard to sell analytics subscriptions,
+or embed it behind a paywall for your clients.
+
+## CLI usage
+
+The CLI is designed for founders who prefer to automate workflows from the terminal:
+
+```bash
+python -m profit_platform.cli --database demo.db init-db
+python -m profit_platform.cli --database demo.db seed-demo
+python -m profit_platform.cli --database demo.db recommend 1
+```
+
+## Testing
+
+```bash
+pytest
+```
+
+## Monetisation ideas
+
+- Offer real-time pricing dashboards to ecommerce brands on a monthly retainer.
+- Bundle bespoke price testing playbooks with consulting engagements.
+- Sell API access to agencies that want to embed smart pricing into their internal tools.

--- a/profit_platform/__init__.py
+++ b/profit_platform/__init__.py
@@ -1,0 +1,7 @@
+"""Profit Platform - pricing optimization toolkit."""
+
+from .api import ProfitPlatformAPI, run_server
+from .pricing import PricingInsight, recommend_price
+from .service import ProfitPlatformService
+
+__all__ = ["ProfitPlatformAPI", "ProfitPlatformService", "PricingInsight", "recommend_price", "run_server"]

--- a/profit_platform/__main__.py
+++ b/profit_platform/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry point for Profit Platform."""
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/profit_platform/api.py
+++ b/profit_platform/api.py
@@ -1,0 +1,167 @@
+"""Minimal WSGI API exposing Profit Platform services."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from typing import Any, Callable
+from wsgiref.simple_server import make_server
+
+from .pricing import PricingInsight
+from .service import ProfitPlatformService
+
+ResponseStart = Callable[[str, list[tuple[str, str]]], None]
+
+
+class ProfitPlatformAPI:
+    def __init__(self, service: ProfitPlatformService | None = None):
+        self.service = service or ProfitPlatformService()
+
+    # WSGI callable -----------------------------------------------------
+    def __call__(self, environ, start_response: ResponseStart):
+        method = environ.get("REQUEST_METHOD", "GET").upper()
+        path = environ.get("PATH_INFO", "")
+
+        try:
+            if method == "GET" and path == "/health":
+                return self._response(start_response, HTTPStatus.OK, {"status": "ok"})
+            if method == "GET" and path == "/products":
+                products = [self._serialize_product(p) for p in self.service.list_products()]
+                return self._response(start_response, HTTPStatus.OK, products)
+            if method == "POST" and path == "/products":
+                payload = self._load_json(environ)
+                product = self.service.create_product(
+                    name=payload["name"],
+                    base_price=float(payload["base_price"]),
+                    target_margin=float(payload.get("target_margin", 0.2)),
+                    description=payload.get("description"),
+                )
+                return self._response(start_response, HTTPStatus.CREATED, self._serialize_product(product))
+            if path.startswith("/products/"):
+                return self._handle_product_routes(method, path, environ, start_response)
+            if method == "POST" and path == "/experiments":
+                payload = self._load_json(environ)
+                experiment = self.service.create_experiment(
+                    product_id=int(payload["product_id"]),
+                    hypothesis=payload["hypothesis"],
+                    control_price=float(payload["control_price"]),
+                    variant_price=float(payload["variant_price"]),
+                    completed=bool(payload.get("completed", False)),
+                )
+                return self._response(start_response, HTTPStatus.CREATED, self._serialize_experiment(experiment))
+            if method == "GET" and path == "/experiments":
+                experiments = [self._serialize_experiment(e) for e in self.service.list_experiments()]
+                return self._response(start_response, HTTPStatus.OK, experiments)
+
+            return self._response(start_response, HTTPStatus.NOT_FOUND, {"detail": "Not found"})
+        except KeyError as exc:
+            return self._response(
+                start_response, HTTPStatus.BAD_REQUEST, {"detail": f"Missing field: {exc.args[0]}"}
+            )
+        except ValueError as exc:
+            return self._response(start_response, HTTPStatus.BAD_REQUEST, {"detail": str(exc)})
+
+    # Internal routing --------------------------------------------------
+    def _handle_product_routes(self, method: str, path: str, environ, start_response: ResponseStart):
+        parts = [p for p in path.split("/") if p]
+        if len(parts) < 2:
+            return self._response(start_response, HTTPStatus.NOT_FOUND, {"detail": "Not found"})
+        product_id = int(parts[1])
+
+        if len(parts) == 2 and method == "GET":
+            product = self.service.get_product(product_id)
+            return self._response(start_response, HTTPStatus.OK, self._serialize_product(product))
+        if len(parts) == 2 and method == "POST":
+            payload = self._load_json(environ)
+            observation = self.service.add_observation(
+                product_id=product_id,
+                price=float(payload["price"]),
+                units_sold=int(payload["units_sold"]),
+                visitors=int(payload["visitors"]),
+            )
+            return self._response(start_response, HTTPStatus.CREATED, self._serialize_observation(observation))
+        if len(parts) == 3 and parts[2] == "observations" and method == "POST":
+            payload = self._load_json(environ)
+            observation = self.service.add_observation(
+                product_id=product_id,
+                price=float(payload["price"]),
+                units_sold=int(payload["units_sold"]),
+                visitors=int(payload["visitors"]),
+            )
+            return self._response(start_response, HTTPStatus.CREATED, self._serialize_observation(observation))
+        if len(parts) == 3 and parts[2] == "insights" and method == "GET":
+            insight = self.service.pricing_insight(product_id)
+            return self._response(start_response, HTTPStatus.OK, self._serialize_insight(insight))
+
+        return self._response(start_response, HTTPStatus.NOT_FOUND, {"detail": "Not found"})
+
+    # Serialisation helpers ---------------------------------------------
+    def _serialize_product(self, product):
+        return {
+            "id": product.id,
+            "name": product.name,
+            "base_price": product.base_price,
+            "target_margin": product.target_margin,
+            "description": product.description,
+            "created_at": product.created_at.isoformat() if product.created_at else None,
+        }
+
+    def _serialize_observation(self, observation):
+        return {
+            "id": observation.id,
+            "product_id": observation.product_id,
+            "price": observation.price,
+            "units_sold": observation.units_sold,
+            "visitors": observation.visitors,
+            "created_at": observation.created_at.isoformat() if observation.created_at else None,
+        }
+
+    def _serialize_experiment(self, experiment):
+        return {
+            "id": experiment.id,
+            "product_id": experiment.product_id,
+            "hypothesis": experiment.hypothesis,
+            "control_price": experiment.control_price,
+            "variant_price": experiment.variant_price,
+            "completed": experiment.completed,
+            "start_date": experiment.start_date.isoformat() if experiment.start_date else None,
+        }
+
+    def _serialize_insight(self, insight: PricingInsight) -> dict[str, Any]:
+        return {
+            "product_id": insight.product_id,
+            "recommended_price": insight.recommended_price,
+            "expected_conversion": insight.expected_conversion,
+            "expected_revenue_per_visitor": insight.expected_revenue_per_visitor,
+            "elasticity": insight.elasticity,
+            "average_conversion": insight.average_conversion,
+            "sample_size": insight.sample_size,
+        }
+
+    # Utility methods ---------------------------------------------------
+    def _load_json(self, environ) -> dict[str, Any]:
+        try:
+            length = int(environ.get("CONTENT_LENGTH", "0") or "0")
+        except ValueError:
+            length = 0
+        body = environ["wsgi.input"].read(length) if length else b""
+        if not body:
+            return {}
+        return json.loads(body.decode("utf-8"))
+
+    def _response(self, start_response: ResponseStart, status: HTTPStatus, payload: Any):
+        body = json.dumps(payload).encode("utf-8")
+        headers = [
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(len(body))),
+        ]
+        start_response(f"{status.value} {status.phrase}", headers)
+        return [body]
+
+
+def run_server(host: str = "127.0.0.1", port: int = 8000, database_path: str | None = None):
+    service = ProfitPlatformService(database_path)
+    app = ProfitPlatformAPI(service)
+    with make_server(host, port, app) as httpd:
+        print(f"Profit Platform API running on http://{host}:{port}")
+        httpd.serve_forever()

--- a/profit_platform/cli.py
+++ b/profit_platform/cli.py
@@ -1,0 +1,88 @@
+"""Command line interface for the Profit Platform."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from .api import run_server
+from .database import create_tables, get_connection
+from .service import ProfitPlatformService
+
+DEFAULT_DATABASE = "profit_platform.db"
+
+
+def init_db(database_path: str) -> None:
+    with get_connection(database_path) as connection:
+        create_tables(connection)
+
+
+def seed_demo(database_path: str) -> None:
+    service = ProfitPlatformService(database_path)
+    product = service.create_product(
+        name="Conversion Boost Course",
+        base_price=149.0,
+        target_margin=0.35,
+        description="Premium training for ecommerce founders",
+    )
+    demo_observations = [
+        (129, 42, 400),
+        (149, 38, 310),
+        (169, 32, 295),
+        (189, 21, 260),
+    ]
+    for price, units, visitors in demo_observations:
+        service.add_observation(product.id, price, units, visitors)
+
+
+def show_insight(database_path: str, product_id: int) -> None:
+    service = ProfitPlatformService(database_path)
+    insight = service.pricing_insight(product_id)
+    print("Recommended price:", f"${insight.recommended_price:.2f}")
+    print("Expected conversion:", f"{insight.expected_conversion*100:.1f}%")
+    print("Revenue per visitor:", f"${insight.expected_revenue_per_visitor:.2f}")
+    if insight.elasticity is not None:
+        print("Estimated elasticity:", f"{insight.elasticity:.2f}")
+    print("Data points used:", insight.sample_size)
+
+
+def serve(database_path: str, host: str, port: int) -> None:
+    run_server(host=host, port=port, database_path=database_path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Profit Platform utilities")
+    parser.add_argument("--database", default=DEFAULT_DATABASE, help="Path to SQLite database")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("init-db", help="Initialise the database")
+    subparsers.add_parser("seed-demo", help="Populate the database with demo data")
+
+    recommend_parser = subparsers.add_parser("recommend", help="Show pricing insight for a product")
+    recommend_parser.add_argument("product_id", type=int)
+
+    serve_parser = subparsers.add_parser("serve", help="Run the Profit Platform API server")
+    serve_parser.add_argument("--host", default="127.0.0.1")
+    serve_parser.add_argument("--port", type=int, default=8000)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "init-db":
+        init_db(args.database)
+    elif args.command == "seed-demo":
+        seed_demo(args.database)
+    elif args.command == "recommend":
+        show_insight(args.database, args.product_id)
+    elif args.command == "serve":
+        serve(args.database, args.host, args.port)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/profit_platform/database.py
+++ b/profit_platform/database.py
@@ -1,0 +1,66 @@
+"""SQLite helpers for the Profit Platform service."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+DEFAULT_DB_PATH = Path("profit_platform.db")
+
+
+def get_connection(database_path: str | Path | None = None) -> sqlite3.Connection:
+    path = Path(database_path or DEFAULT_DB_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def create_tables(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS product (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            base_price REAL NOT NULL,
+            target_margin REAL NOT NULL,
+            description TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS price_observation (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            product_id INTEGER NOT NULL REFERENCES product(id) ON DELETE CASCADE,
+            price REAL NOT NULL,
+            units_sold INTEGER NOT NULL,
+            visitors INTEGER NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS price_experiment (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            product_id INTEGER NOT NULL REFERENCES product(id) ON DELETE CASCADE,
+            hypothesis TEXT NOT NULL,
+            control_price REAL NOT NULL,
+            variant_price REAL NOT NULL,
+            start_date TEXT DEFAULT CURRENT_TIMESTAMP,
+            completed INTEGER DEFAULT 0
+        );
+        """
+    )
+    connection.commit()
+
+
+@contextmanager
+def session_scope(database_path: str | Path | None = None) -> Iterator[sqlite3.Connection]:
+    connection = get_connection(database_path)
+    try:
+        yield connection
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()

--- a/profit_platform/models.py
+++ b/profit_platform/models.py
@@ -1,0 +1,42 @@
+"""Domain models for Profit Platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Product:
+    name: str
+    base_price: float
+    target_margin: float
+    description: Optional[str] = None
+    id: Optional[int] = None
+    created_at: Optional[datetime] = None
+
+
+@dataclass
+class PriceObservation:
+    product_id: int
+    price: float
+    units_sold: int
+    visitors: int
+    id: Optional[int] = None
+    created_at: Optional[datetime] = None
+
+    @property
+    def conversion_rate(self) -> float:
+        return self.units_sold / self.visitors if self.visitors else 0.0
+
+
+@dataclass
+class PriceExperiment:
+    product_id: int
+    hypothesis: str
+    control_price: float
+    variant_price: float
+    completed: bool = False
+    id: Optional[int] = None
+    start_date: Optional[datetime] = None

--- a/profit_platform/pricing.py
+++ b/profit_platform/pricing.py
@@ -1,0 +1,110 @@
+"""Pricing intelligence utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Iterable, Sequence
+
+from .models import PriceObservation, Product
+
+
+@dataclass
+class PricingInsight:
+    product_id: int
+    recommended_price: float
+    expected_conversion: float
+    expected_revenue_per_visitor: float
+    elasticity: float | None
+    average_conversion: float
+    sample_size: int
+
+
+def _linear_regression(xs: Sequence[float], ys: Sequence[float]) -> tuple[float, float] | None:
+    if len(xs) != len(ys) or len(xs) < 2:
+        return None
+    mean_x = mean(xs)
+    mean_y = mean(ys)
+    numerator = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    denominator = sum((x - mean_x) ** 2 for x in xs)
+    if denominator == 0:
+        return None
+    slope = numerator / denominator
+    intercept = mean_y - slope * mean_x
+    return slope, intercept
+
+
+def _bounded_prediction(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def calculate_elasticity(observations: Iterable[PriceObservation]) -> float | None:
+    obs_list = list(observations)
+    if len(obs_list) < 2:
+        return None
+    prices = [obs.price for obs in obs_list]
+    conversions = [obs.conversion_rate for obs in obs_list]
+    regression = _linear_regression(prices, conversions)
+    if regression is None:
+        return None
+    slope, _intercept = regression
+    mean_price = mean(prices)
+    mean_conversion = mean(conversions)
+    if mean_conversion == 0 or mean_price == 0:
+        return None
+    elasticity = slope * mean_price / mean_conversion
+    return elasticity
+
+
+def recommend_price(product: Product, observations: Sequence[PriceObservation]) -> PricingInsight:
+    obs_list = list(observations)
+    if not obs_list:
+        margin_price = product.base_price * (1 + product.target_margin)
+        return PricingInsight(
+            product_id=product.id or -1,
+            recommended_price=margin_price,
+            expected_conversion=0.15,
+            expected_revenue_per_visitor=margin_price * 0.15,
+            elasticity=None,
+            average_conversion=0.0,
+            sample_size=0,
+        )
+
+    prices = [obs.price for obs in obs_list]
+    conversions = [obs.conversion_rate for obs in obs_list]
+    regression = _linear_regression(prices, conversions)
+    average_conversion = mean(conversions)
+    elasticity = calculate_elasticity(obs_list)
+
+    def conversion_at(price: float) -> float:
+        if regression is None:
+            return average_conversion
+        slope, intercept = regression
+        return _bounded_prediction(intercept + slope * price)
+
+    search_prices = [round(p, 2) for p in _generate_price_candidates(product.base_price, prices)]
+    best_price = max(search_prices, key=lambda price: price * conversion_at(price))
+    expected_conversion = conversion_at(best_price)
+    expected_revenue = best_price * expected_conversion
+
+    return PricingInsight(
+        product_id=product.id or -1,
+        recommended_price=best_price,
+        expected_conversion=expected_conversion,
+        expected_revenue_per_visitor=expected_revenue,
+        elasticity=elasticity,
+        average_conversion=average_conversion,
+        sample_size=len(obs_list),
+    )
+
+
+def _generate_price_candidates(base_price: float, observed_prices: Sequence[float]) -> list[float]:
+    floor_price = min(observed_prices + [base_price * 0.6])
+    ceiling_price = max(observed_prices + [base_price * 1.6])
+    step = max(base_price * 0.02, 0.25)
+    price = floor_price
+    candidates = []
+    while price <= ceiling_price:
+        candidates.append(round(price, 2))
+        price += step
+    return sorted(set(candidates + [base_price]))

--- a/profit_platform/service.py
+++ b/profit_platform/service.py
@@ -1,0 +1,192 @@
+"""Domain service layer for Profit Platform."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from .database import create_tables, get_connection
+from .models import PriceExperiment, PriceObservation, Product
+from .pricing import PricingInsight, recommend_price
+
+
+class ProfitPlatformService:
+    """High level API for managing products and pricing data."""
+
+    def __init__(self, database_path: str | Path | None = None):
+        self.database_path = database_path
+        with get_connection(self.database_path) as connection:
+            create_tables(connection)
+
+    # Product management -------------------------------------------------
+    def create_product(
+        self, name: str, base_price: float, target_margin: float, description: str | None = None
+    ) -> Product:
+        with get_connection(self.database_path) as connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO product (name, base_price, target_margin, description)
+                VALUES (?, ?, ?, ?)
+                """,
+                (name, base_price, target_margin, description),
+            )
+            product_id = cursor.lastrowid
+            row = connection.execute(
+                "SELECT id, name, base_price, target_margin, description, created_at FROM product WHERE id = ?",
+                (product_id,),
+            ).fetchone()
+        return _row_to_product(row)
+
+    def list_products(self) -> List[Product]:
+        with get_connection(self.database_path) as connection:
+            rows = connection.execute(
+                "SELECT id, name, base_price, target_margin, description, created_at FROM product ORDER BY id"
+            ).fetchall()
+        return [_row_to_product(row) for row in rows]
+
+    # Observations -------------------------------------------------------
+    def add_observation(
+        self, product_id: int, price: float, units_sold: int, visitors: int
+    ) -> PriceObservation:
+        with get_connection(self.database_path) as connection:
+            self._ensure_product_exists(connection, product_id)
+            cursor = connection.execute(
+                """
+                INSERT INTO price_observation (product_id, price, units_sold, visitors)
+                VALUES (?, ?, ?, ?)
+                """,
+                (product_id, price, units_sold, visitors),
+            )
+            obs_id = cursor.lastrowid
+            row = connection.execute(
+                "SELECT id, product_id, price, units_sold, visitors, created_at FROM price_observation WHERE id = ?",
+                (obs_id,),
+            ).fetchone()
+        return _row_to_observation(row)
+
+    def list_observations(self, product_id: int) -> List[PriceObservation]:
+        with get_connection(self.database_path) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, product_id, price, units_sold, visitors, created_at
+                FROM price_observation WHERE product_id = ? ORDER BY created_at
+                """,
+                (product_id,),
+            ).fetchall()
+        return [_row_to_observation(row) for row in rows]
+
+    def pricing_insight(self, product_id: int) -> PricingInsight:
+        product = self.get_product(product_id)
+        observations = self.list_observations(product_id)
+        return recommend_price(product, observations)
+
+    def get_product(self, product_id: int) -> Product:
+        with get_connection(self.database_path) as connection:
+            row = connection.execute(
+                "SELECT id, name, base_price, target_margin, description, created_at FROM product WHERE id = ?",
+                (product_id,),
+            ).fetchone()
+        if not row:
+            raise ValueError(f"Product {product_id} not found")
+        return _row_to_product(row)
+
+    # Experiments --------------------------------------------------------
+    def create_experiment(
+        self,
+        product_id: int,
+        hypothesis: str,
+        control_price: float,
+        variant_price: float,
+        completed: bool = False,
+    ) -> PriceExperiment:
+        with get_connection(self.database_path) as connection:
+            self._ensure_product_exists(connection, product_id)
+            cursor = connection.execute(
+                """
+                INSERT INTO price_experiment (product_id, hypothesis, control_price, variant_price, completed)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (product_id, hypothesis, control_price, variant_price, int(completed)),
+            )
+            exp_id = cursor.lastrowid
+            row = connection.execute(
+                """
+                SELECT id, product_id, hypothesis, control_price, variant_price, completed, start_date
+                FROM price_experiment WHERE id = ?
+                """,
+                (exp_id,),
+            ).fetchone()
+        return _row_to_experiment(row)
+
+    def list_experiments(self, product_id: Optional[int] = None) -> List[PriceExperiment]:
+        with get_connection(self.database_path) as connection:
+            if product_id is None:
+                rows = connection.execute(
+                    """
+                    SELECT id, product_id, hypothesis, control_price, variant_price, completed, start_date
+                    FROM price_experiment ORDER BY start_date DESC
+                    """
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    """
+                    SELECT id, product_id, hypothesis, control_price, variant_price, completed, start_date
+                    FROM price_experiment WHERE product_id = ? ORDER BY start_date DESC
+                    """,
+                    (product_id,),
+                ).fetchall()
+        return [_row_to_experiment(row) for row in rows]
+
+    # Internal helpers ---------------------------------------------------
+    @staticmethod
+    def _ensure_product_exists(connection, product_id: int) -> None:
+        row = connection.execute("SELECT id FROM product WHERE id = ?", (product_id,)).fetchone()
+        if not row:
+            raise ValueError(f"Product {product_id} not found")
+
+
+def _row_to_product(row) -> Product:
+    created_at = _parse_datetime(row["created_at"]) if row["created_at"] else None
+    return Product(
+        id=row["id"],
+        name=row["name"],
+        base_price=row["base_price"],
+        target_margin=row["target_margin"],
+        description=row["description"],
+        created_at=created_at,
+    )
+
+
+def _row_to_observation(row) -> PriceObservation:
+    created_at = _parse_datetime(row["created_at"]) if row["created_at"] else None
+    return PriceObservation(
+        id=row["id"],
+        product_id=row["product_id"],
+        price=row["price"],
+        units_sold=row["units_sold"],
+        visitors=row["visitors"],
+        created_at=created_at,
+    )
+
+
+def _row_to_experiment(row) -> PriceExperiment:
+    start_date = _parse_datetime(row["start_date"]) if row["start_date"] else None
+    return PriceExperiment(
+        id=row["id"],
+        product_id=row["product_id"],
+        hypothesis=row["hypothesis"],
+        control_price=row["control_price"],
+        variant_price=row["variant_price"],
+        completed=bool(row["completed"]),
+        start_date=start_date,
+    )
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "profit-platform"
+version = "0.1.0"
+description = "Pricing intelligence SaaS starter kit"
+readme = "README.md"
+authors = [{name = "AI Assistant"}]
+requires-python = ">=3.11"
+
+[project.scripts]
+profit-platform = "profit_platform.cli:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from profit_platform.service import ProfitPlatformService
+
+
+@pytest.fixture()
+def service(tmp_path):
+    db_path = tmp_path / "test.db"
+    return ProfitPlatformService(db_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,64 @@
+import json
+from io import BytesIO
+
+from profit_platform.api import ProfitPlatformAPI
+from profit_platform.service import ProfitPlatformService
+
+
+def test_product_insights_flow(service: ProfitPlatformService):
+    product = service.create_product(
+        name="AI Funnel Optimizer",
+        base_price=120.0,
+        target_margin=0.4,
+        description="Premium SaaS for ecommerce pricing",
+    )
+
+    observations = [
+        (110, 30, 200),
+        (130, 26, 210),
+        (150, 18, 205),
+    ]
+    for price, units, visitors in observations:
+        service.add_observation(product.id, price, units, visitors)
+
+    insight = service.pricing_insight(product.id)
+    assert insight.product_id == product.id
+    assert 0 <= insight.expected_conversion <= 1
+    assert insight.sample_size == len(observations)
+    assert insight.expected_revenue_per_visitor >= 0
+
+    experiment = service.create_experiment(
+        product_id=product.id,
+        hypothesis="Higher urgency messaging will sustain conversions at $140",
+        control_price=130,
+        variant_price=140,
+    )
+    experiments = service.list_experiments(product.id)
+    assert experiments[0].id == experiment.id
+    assert experiments[0].hypothesis.startswith("Higher urgency")
+
+
+def test_wsgi_health_endpoint(service: ProfitPlatformService):
+    api = ProfitPlatformAPI(service)
+    status, body = _wsgi_request(api, "GET", "/health")
+    assert status.startswith("200")
+    assert json.loads(body) == {"status": "ok"}
+
+
+def _wsgi_request(app, method: str, path: str, payload: dict | None = None):
+    body_bytes = json.dumps(payload).encode("utf-8") if payload is not None else b""
+    environ = {
+        "REQUEST_METHOD": method,
+        "PATH_INFO": path,
+        "CONTENT_LENGTH": str(len(body_bytes)),
+        "wsgi.input": BytesIO(body_bytes),
+    }
+    response = {}
+
+    def start_response(status_line, headers):
+        response["status"] = status_line
+        response["headers"] = headers
+
+    chunks = app(environ, start_response)
+    body = b"".join(chunks).decode("utf-8")
+    return response["status"], body


### PR DESCRIPTION
## Summary
- replace the previous wealth-builder scripts with a Profit Platform pricing-intelligence toolkit
- implement SQLite-backed domain models, pricing analytics, CLI utilities, and a lightweight WSGI JSON API
- add tests exercising the pricing workflow and web entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd97d89d708325a2be57f88ddd1008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a lightweight HTTP API for health checks, products, observations, pricing insights, and experiments.
  - Adds a command-line interface to initialize the database, seed demo data, get pricing recommendations, and run the server.
  - Provides pricing intelligence with elasticity estimation and revenue-optimizing price recommendations.
- Documentation
  - Overhauls README with feature overview, quick start, usage examples, and testing instructions.
- Chores
  - Adds packaging configuration with a console entry point.
  - Updates ignore rules for Python bytecode.
- Tests
  - Adds end-to-end tests for insights, experiments, and API health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->